### PR TITLE
support for icons in ScrollableTabBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ See
 - **`tabBarBackgroundColor`** _(String)_ - color of the default tab bar's background, defaults to `white`
 - **`tabBarActiveTextColor`** _(String)_ - color of the default tab bar's text when active, defaults to `navy`
 - **`tabBarInactiveTextColor`** _(String)_ - color of the default tab bar's text when inactive, defaults to `black`
+- - **`tabBarUseIcons`** _(Bool)_ - instead of text tabs, tab bar will use `tabLabel` properties of ScrollableTabView children elements to select icons from *[react-native-vector-icons](https://github.com/oblador/react-native-vector-icons)* `false`
+- - **`tabBarScrollEnabled`** _(Bool)_ - enable scrolling of tab bar, defaults to `false`
 - **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))_
 - **`contentProps`** _(Object)_ - props that are applied to root `ScrollView`/`ViewPagerAndroid`. Note that overriding defaults set by the library may break functionality; see the source for details.
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ See
 - **`tabBarBackgroundColor`** _(String)_ - color of the default tab bar's background, defaults to `white`
 - **`tabBarActiveTextColor`** _(String)_ - color of the default tab bar's text when active, defaults to `navy`
 - **`tabBarInactiveTextColor`** _(String)_ - color of the default tab bar's text when inactive, defaults to `black`
-- - **`tabBarUseIcons`** _(Bool)_ - instead of text tabs, tab bar will use `tabLabel` properties of ScrollableTabView children elements to select icons from *[react-native-vector-icons](https://github.com/oblador/react-native-vector-icons)* `false`
-- - **`tabBarScrollEnabled`** _(Bool)_ - enable scrolling of tab bar, defaults to `false`
+- **`tabBarUseIcons`** _(Bool)_ - instead of text tabs, tab bar will use `tabLabel` properties of ScrollableTabView children elements to select icons from *[react-native-vector-icons](https://github.com/oblador/react-native-vector-icons)*, defaults to `false`
+- **`tabBarScrollEnabled`** _(Bool)_ - enable scrolling of tab bar, defaults to `false`
 - **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))_
 - **`contentProps`** _(Object)_ - props that are applied to root `ScrollView`/`ViewPagerAndroid`. Note that overriding defaults set by the library may break functionality; see the source for details.
 

--- a/examples/FacebookTabsExample/FacebookTabBar.js
+++ b/examples/FacebookTabsExample/FacebookTabBar.js
@@ -10,6 +10,7 @@ var {
 } = React;
 
 const Icon = require('react-native-vector-icons/Ionicons');
+const AnimatedIcon = Animated.createAnimatedComponent(Icon);
 
 var styles = StyleSheet.create({
   tab: {
@@ -19,7 +20,7 @@ var styles = StyleSheet.create({
     paddingBottom: 10,
   },
   tabs: {
-    height: 45,
+    height: 50,
     flexDirection: 'row',
     paddingTop: 5,
     borderWidth: 1,
@@ -30,7 +31,7 @@ var styles = StyleSheet.create({
   },
   icon: {
     position: 'absolute',
-    top: 0,
+    top: 4,
     left: 20,
   },
 });
@@ -42,18 +43,31 @@ var FacebookTabBar = React.createClass({
   propTypes: {
     goToPage: React.PropTypes.func,
     activeTab: React.PropTypes.number,
-    tabs: React.PropTypes.array
+    tabs: React.PropTypes.array,
+    underlineColor : React.PropTypes.string,
+    backgroundColor : React.PropTypes.string,
+    activeTextColor : React.PropTypes.string,
+    inactiveTextColor : React.PropTypes.string,
   },
 
   renderTabOption(name, page) {
     var isTabActive = this.props.activeTab === page;
 
+    let inputRange = [page -1, page, page+1];
+
+    var iconScale = this.props.scrollValue.interpolate({
+      inputRange: inputRange,
+      outputRange: [.95, 1.15, .95],
+      extrapolate: 'clamp'
+    });
+
     return (
       <TouchableOpacity key={name} onPress={() => this.props.goToPage(page)} style={styles.tab}>
-        <Icon name={name} size={30} color='#3B5998' style={styles.icon}
-              ref={(icon) => { this.selectedTabIcons[page] = icon }}/>
-        <Icon name={name} size={30} color='#ccc' style={styles.icon}
-              ref={(icon) => { this.unselectedTabIcons[page] = icon }}/>
+        <AnimatedIcon name={name} size={30} color={this.props.activeTextColor} style={[styles.icon, {transform:[{scale: iconScale}]}]}
+            ref={(icon) => { this.selectedTabIcons[page] = icon }}/>
+
+        <AnimatedIcon name={name} size={30} color={this.props.inactiveTextColor} style={[styles.icon, {transform:[{scale: iconScale}]}]}
+        ref={(icon) => { this.unselectedTabIcons[page] = icon }}/>
       </TouchableOpacity>
     );
   },
@@ -89,20 +103,20 @@ var FacebookTabBar = React.createClass({
       position: 'absolute',
       width: containerWidth / numberOfTabs,
       height: 3,
-      backgroundColor: '#3b5998',
+      backgroundColor: this.props.underlineColor,
       bottom: 0,
     };
 
-    var left = this.props.scrollValue.interpolate({
+    var translateX = this.props.scrollValue.interpolate({
       inputRange: [0, 1], outputRange: [0, containerWidth / numberOfTabs]
     });
 
     return (
       <View>
-        <View style={[styles.tabs, this.props.style, ]}>
+        <View style={[styles.tabs, this.props.style, {backgroundColor: this.props.backgroundColor}]}>
           {this.props.tabs.map((tab, i) => this.renderTabOption(tab, i))}
         </View>
-        <Animated.View style={[tabUnderlineStyle, {left}]} />
+        <Animated.View style={[tabUnderlineStyle, {transform:[{translateX: translateX}]}]} />
       </View>
     );
   },

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const ScrollableTabView = React.createClass({
           {this._children().map((child, idx) => {
             return <View
               key={child.props.tabLabel + '_' + idx}
-              style={{width: this.state.containerWidth, }}>
+              style={{width: this.props.children.length - 1 === idx ?  this.state.containerWidth - this.props.gap : this.state.containerWidth, }}>
               {child}
             </View>;
           })}

--- a/index.js
+++ b/index.js
@@ -99,11 +99,17 @@ const ScrollableTabView = React.createClass({
           }}
           onMomentumScrollBegin={(e) => {
             const offsetX = e.nativeEvent.contentOffset.x;
-            this._updateSelectedPage(parseInt(offsetX / this.state.containerWidth, 10));
+            const page = Math.round(offsetX / this.state.containerWidth);
+            if(this.state.currentPage != page){
+              this._updateSelectedPage(page);
+            }
           }}
           onMomentumScrollEnd={(e) => {
             const offsetX = e.nativeEvent.contentOffset.x;
-            this._updateSelectedPage(parseInt(offsetX / this.state.containerWidth, 10));
+            const page = Math.round(offsetX / this.state.containerWidth);
+            if(this.state.currentPage != page){
+              this._updateSelectedPage(page);
+            }
           }}
           scrollEventThrottle={16}
           scrollsToTop={false}

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const ScrollableTabView = React.createClass({
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
     style: View.propTypes.style,
+    contentProps: PropTypes.object,
   },
 
   getDefaultProps() {
@@ -37,6 +38,7 @@ const ScrollableTabView = React.createClass({
       page: -1,
       onChangeTab: () => {},
       onScroll: () => {},
+      contentProps: {}
     };
   },
 
@@ -104,7 +106,9 @@ const ScrollableTabView = React.createClass({
           showsHorizontalScrollIndicator={false}
           scrollEnabled={!this.props.locked}
           directionalLockEnabled
-          alwaysBounceVertical={false}>
+          alwaysBounceVertical={false}
+          {...this.props.contentProps}
+          >
           {this._children().map((child, idx) => {
             return <View
               key={child.props.tabLabel + '_' + idx}
@@ -124,7 +128,8 @@ const ScrollableTabView = React.createClass({
            const { offset, position, } = e.nativeEvent;
            this._updateScrollValue(position + offset);
          }}
-         ref={(scrollView) => { this.scrollView = scrollView; }}>
+         ref={(scrollView) => { this.scrollView = scrollView; }}
+         {...this.props.contentProps}>
          {this._children().map((child, idx) => {
            return <View
              key={child.props.tabLabel + '_' + idx}

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ const ScrollableTabView = React.createClass({
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
     style: View.propTypes.style,
-    contentProps: PropTypes.object
   },
 
   getDefaultProps() {
@@ -38,7 +37,6 @@ const ScrollableTabView = React.createClass({
       page: -1,
       onChangeTab: () => {},
       onScroll: () => {},
-      contentProps: {}
     };
   },
 
@@ -106,8 +104,7 @@ const ScrollableTabView = React.createClass({
           showsHorizontalScrollIndicator={false}
           scrollEnabled={!this.props.locked}
           directionalLockEnabled
-          alwaysBounceVertical={false}
-          {...this.props.contentProps}>
+          alwaysBounceVertical={false}>
           {this._children().map((child, idx) => {
             return <View
               key={child.props.tabLabel + '_' + idx}
@@ -127,8 +124,7 @@ const ScrollableTabView = React.createClass({
            const { offset, position, } = e.nativeEvent;
            this._updateScrollValue(position + offset);
          }}
-         ref={(scrollView) => { this.scrollView = scrollView; }}
-         {...this.props.contentProps}>
+         ref={(scrollView) => { this.scrollView = scrollView; }}>
          {this._children().map((child, idx) => {
            return <View
              key={child.props.tabLabel + '_' + idx}
@@ -197,6 +193,12 @@ const ScrollableTabView = React.createClass({
     }
     if (this.props.tabBarInactiveTextColor) {
       tabBarProps.inactiveTextColor = this.props.tabBarInactiveTextColor;
+    }
+    if (this.props.tabBarUseIcons) {
+      tabBarProps.useIcons = this.props.tabBarUseIcons;
+    }
+    if (this.props.tabBarScrollEnabled) {
+      tabBarProps.scrollEnabled = this.props.tabBarScrollEnabled;
     }
     if (overlayTabs) {
       tabBarProps.style = {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ const ScrollableTabView = React.createClass({
   },
 
   getDefaultProps() {
-    console.log('HELP', this.props)
     return {
       tabBarPosition: 'top',
       initialPage: 0,


### PR DESCRIPTION
can be turned on with props `tabBarUseIcons` and `tabBarScrollEnabled`. So that also means that this component won't scroll by default anymore--perhaps it can be used as the one and only tab bar (i.e. you can delete `DefaultTabBar`). Either way, it's up to you. 

One minor issue when there are more than 5 icons and scrolling is enabled is that if the initial page is, say, index 2 in a 5 page tab view, then the scrolling component will load offset a little bit, when obviously the product intent is to have the middle tab icon highlighted with left side of the tab bar aligned perfectly on the left side. It's a minor thing and probably can be manually fixed via some `ScrollView` param. But it might be nice to not offset the scrollview unless the selected tab is off the screen.