### PR TITLE
Make TabBar API more flexible and improve FB example accessibility

### DIFF
--- a/DefaultTabBar.js
+++ b/DefaultTabBar.js
@@ -41,21 +41,21 @@ var DefaultTabBar = React.createClass({
     inactiveTextColor : React.PropTypes.string,
   },
 
-  renderTabOption(name, page) {
+  renderTabOption(tab, page) {
     var isTabActive = this.props.activeTab === page;
     var activeTextColor = this.props.activeTextColor || "navy";
     var inactiveTextColor = this.props.inactiveTextColor || "black";
     return (
       <TouchableOpacity
-        key={name}
+        key={tab.props.key || tab.props.tabLabel}
         accessible={true}
-        accessibilityLabel={name}
+        accessibilityLabel={tab.props.tabLabel}
         accessibilityTraits='button'
         style={[styles.tab]}
         onPress={() => this.props.goToPage(page)}>
         <View>
           <Text style={{color: isTabActive ? activeTextColor : inactiveTextColor,
-            fontWeight: isTabActive ? 'bold' : 'normal'}}>{name}</Text>
+            fontWeight: isTabActive ? 'bold' : 'normal'}}>{tab.props.tabLabel}</Text>
         </View>
       </TouchableOpacity>
     );

--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -93,23 +93,23 @@ var ScrollableTabBar = React.createClass({
     }
   },
 
-  renderTabOption(name, page) {
+  renderTabOption(tab, page) {
     const isTabActive = this.props.activeTab === page;
     const activeTextColor = this.props.activeTextColor || "navy";
     const inactiveTextColor = this.props.inactiveTextColor || "black";
     return (
       <TouchableOpacity
-        key={name}
+        key={tab.props.key || tab.props.tabLabel}
         ref={'tab_' + page}
         accessible={true}
-        accessibilityLabel={name}
+        accessibilityLabel={tab.props.tabLabel}
         accessibilityTraits='button'
         style={[styles.tab]}
         onPress={() => this.props.goToPage(page)}
         onLayout={this.measureTab.bind(this, page)}
       >
         <View>
-          <Text style={{color: isTabActive ? activeTextColor : inactiveTextColor}}>{name}</Text>
+          <Text style={{color: isTabActive ? activeTextColor : inactiveTextColor}}>{tab.props.tabLabel}</Text>
         </View>
       </TouchableOpacity>
     );

--- a/examples/FacebookTabsExample/FacebookTabBar.js
+++ b/examples/FacebookTabsExample/FacebookTabBar.js
@@ -45,14 +45,20 @@ var FacebookTabBar = React.createClass({
     tabs: React.PropTypes.array
   },
 
-  renderTabOption(name, page) {
+  renderTabOption(tab, page) {
     var isTabActive = this.props.activeTab === page;
 
     return (
-      <TouchableOpacity key={name} onPress={() => this.props.goToPage(page)} style={styles.tab}>
-        <Icon name={name} size={30} color='#3B5998' style={styles.icon}
+      <TouchableOpacity
+        key={tab.props.key || tab.props.tabLabel}
+        accessible={true}
+        accessibilityLabel={tab.props.tabLabel}
+        accessibilityTraits='button'
+        style={styles.tab}
+        onPress={() => this.props.goToPage(page)}>
+        <Icon name={tab.props.tabIcon} size={30} color='#3B5998' style={styles.icon}
               ref={(icon) => { this.selectedTabIcons[page] = icon }}/>
-        <Icon name={name} size={30} color='#ccc' style={styles.icon}
+        <Icon name={tab.props.tabIcon} size={30} color='#ccc' style={styles.icon}
               ref={(icon) => { this.unselectedTabIcons[page] = icon }}/>
       </TouchableOpacity>
     );

--- a/examples/FacebookTabsExample/FacebookTabsExample.js
+++ b/examples/FacebookTabsExample/FacebookTabsExample.js
@@ -13,27 +13,27 @@ const FacebookTabsExample = React.createClass({
   render() {
     return <View style={styles.container}>
       <ScrollableTabView initialPage={1} renderTabBar={() => <FacebookTabBar />}>
-        <ScrollView tabLabel="ios-paper" style={styles.tabView}>
+        <ScrollView tabLabel="News" tabIcon="ios-paper" style={styles.tabView}>
           <View style={styles.card}>
             <Text>News</Text>
           </View>
         </ScrollView>
-        <ScrollView tabLabel="person-stalker" style={styles.tabView}>
+        <ScrollView tabLabel="Friends" tabIcon="person-stalker" style={styles.tabView}>
           <View style={styles.card}>
             <Text>Friends</Text>
           </View>
         </ScrollView>
-        <ScrollView tabLabel="ios-chatboxes" style={styles.tabView}>
+        <ScrollView tabLabel="Messenger" tabIcon="ios-chatboxes" style={styles.tabView}>
           <View style={styles.card}>
             <Text>Messenger</Text>
           </View>
         </ScrollView>
-        <ScrollView tabLabel="ios-world" style={styles.tabView}>
+        <ScrollView tabLabel="Notifications" tabIcon="ios-world" style={styles.tabView}>
           <View style={styles.card}>
             <Text>Notifications</Text>
           </View>
         </ScrollView>
-        <ScrollView tabLabel="navicon-round" style={styles.tabView}>
+        <ScrollView tabLabel="Other nav" tabIcon="navicon-round" style={styles.tabView}>
           <View style={styles.card}>
             <Text>Other nav</Text>
           </View>

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ const ScrollableTabView = React.createClass({
     let overlayTabs = (this.props.tabBarPosition === 'overlayTop' || this.props.tabBarPosition === 'overlayBottom');
     let tabBarProps = {
       goToPage: this.goToPage,
-      tabs: this._children().map((child) => child.props.tabLabel),
+      tabs: this._children(),
       activeTab: this.state.currentPage,
       scrollValue: this.state.scrollValue,
       containerWidth: this.state.containerWidth,


### PR DESCRIPTION
@skv-headless like suggested in https://github.com/brentvatne/react-native-scrollable-tab-view/pull/186#issuecomment-196015812 i've created a second PR to fix the FB example accessibility.

This version includes an API change which allow custom TabBars to use all informations from the child elements. This makes it possible to use other props of the child then only tabLabel.
