### PR TITLE
Add ability to disable scroll on android viewpager

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ const ScrollableTabView = React.createClass({
          initialPage={this.props.initialPage}
          onPageSelected={this._updateSelectedPage}
          keyboardDismissMode="on-drag"
+         scrollEnabled={!this.props.locked}
          onPageScroll={(e) => {
            const { offset, position, } = e.nativeEvent;
            this._updateScrollValue(position + offset);


### PR DESCRIPTION
Since RN 0.26 the ScrollEnabled prop works on android's ViewPager.
Fixes #95 