### PR TITLE
add keyboardShouldPersistTaps in ScrollView

### DIFF
--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -173,6 +173,7 @@ const ScrollableTabBar = React.createClass({
         directionalLockEnabled={true}
         scrollEventThrottle={16}
         bounces={false}
+        keyboardShouldPersistTaps
       >
         <View
           style={[styles.tabs, {width: this.state._containerWidth, }, this.props.tabsContainerStyle]}


### PR DESCRIPTION
To avoid double-click need when try to press the tab from another focused input