### PR TITLE
Fix for 0.28.0-rc.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,6 @@ const ScrollableTabView = React.createClass({
           horizontal
           pagingEnabled
           automaticallyAdjustContentInsets={false}
-          style={styles.scrollableContentIOS}
-          contentContainerStyle={styles.scrollableContentContainerIOS}
           contentOffset={{ x: this.props.initialPage * this.state.containerWidth, }}
           ref={(scrollView) => { this.scrollView = scrollView; }}
           onScroll={(e) => {
@@ -245,12 +243,6 @@ module.exports = ScrollableTabView;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  scrollableContentContainerIOS: {
-    flex: 1,
-  },
-  scrollableContentIOS: {
-    flexDirection: 'column',
   },
   scrollableContentAndroid: {
     flex: 1,


### PR DESCRIPTION
Dunno if it's a bug from react-native or if they intentionally broke the ScrollView behavior, but in 0.28.0-rc.0 if the contentContainer has flex: 1, the ScrollView doesn't scroll.

No idea as to why the flexDirection comes into play here, just trial and error.

It's not really intended to be merged as of yet (since more info is needed), but more as a way to publicize a workaround for #299.