### PR TITLE
Lazy loading for scrollable Tabs during mounting and rendering.

### DIFF
--- a/SceneComponent.js
+++ b/SceneComponent.js
@@ -5,17 +5,15 @@ const {View, StyleSheet, } = ReactNative;
 
 const StaticContainer = require('react-static-container');
 
-class SceneComponent extends Component {
-  render() {
-    let {selected, ...props, } = this.props;
-    return(
-      <View {...props}>
-        <StaticContainer shouldUpdate={selected}>
-          {this.props.children}
-        </StaticContainer>
-      </View>
-    );
-  }
+const SceneComponent = (Props) => {
+  const {selected, ...props, } = Props;
+  return(
+    <View {...props}>
+      <StaticContainer shouldUpdate={selected}>
+        {props.children}
+      </StaticContainer>
+    </View>
+  );
 }
 
 module.exports = SceneComponent;

--- a/SceneComponent.js
+++ b/SceneComponent.js
@@ -1,0 +1,21 @@
+const React = require('react');
+const ReactNative = require('react-native');
+const {Component, } = React;
+const {View, StyleSheet, } = ReactNative;
+
+const StaticContainer = require('react-static-container');
+
+class SceneComponent extends Component {
+  render() {
+    let {selected, ...props, } = this.props;
+    return(
+      <View {...props}>
+        <StaticContainer shouldUpdate={selected}>
+          {this.props.children}
+        </StaticContainer>
+      </View>
+    );
+  }
+}
+
+module.exports = SceneComponent;

--- a/SceneComponent.js
+++ b/SceneComponent.js
@@ -14,6 +14,6 @@ const SceneComponent = (Props) => {
       </StaticContainer>
     </View>
   );
-}
+};
 
 module.exports = SceneComponent;

--- a/SceneComponent.js
+++ b/SceneComponent.js
@@ -7,13 +7,11 @@ const StaticContainer = require('react-static-container');
 
 const SceneComponent = (Props) => {
   const {selected, ...props, } = Props;
-  return(
-    <View {...props}>
+  return <View {...props}>
       <StaticContainer shouldUpdate={selected}>
         {props.children}
       </StaticContainer>
-    </View>
-  );
+  </View>;
 };
 
 module.exports = SceneComponent;

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ const ScrollableTabView = React.createClass({
 
   renderScrollableContent() {
     if (Platform.OS === 'ios') {
-      let scenes = this._composeScenes();
+      const scenes = this._composeScenes();
       return (
         <ScrollView
           horizontal
@@ -164,7 +164,7 @@ const ScrollableTabView = React.createClass({
         </ScrollView>
       );
     } else {
-      let scenes = this._composeScenes();
+      const scenes = this._composeScenes();
       return (
         <ViewPagerAndroid
          style={styles.scrollableContentAndroid}
@@ -185,40 +185,17 @@ const ScrollableTabView = React.createClass({
   },
 
   _composeScenes() {
-    let scenes = [];
-    this._children().forEach((child, idx) => {
+    return this._children().map((child, idx) => {
       let key = this._makeSceneKey(child, idx);
-      let selected = false;
-
-      // if key doesnt exist(typically before each tab is first mounted) then put a dummy child instead of real
-      // this ensures # of pages remain the same , leaving scrolling and click tab effect to be handled as intended
-      if(!this._keyExists(this.state.sceneKeys, key)) {
-        let scene = (
-          <SceneComponent
+      return (
+        <SceneComponent
           key={key}
           style={{width: this.state.containerWidth, }}
-          selected={selected}>
-            <View tabLabel={child.props.tabLabel}/>
-          </SceneComponent>
-        );
-        scenes.push(scene);
-      }
-      // if keyexists and the tab is viewed for the first time then SceneComponent is mounted, else its updated and rendered
-      // Also when a tab is selected,StaticContainer inside the SceneComponent makes sure that only tab being viewed is rendered
-      if(this._keyExists(this.state.sceneKeys, key)) {
-        if(idx === this.state.currentPage) selected = true;
-        let scene = (
-          <SceneComponent
-          key={key}
-          style={{width: this.state.containerWidth, }}
-          selected={selected}>
-            {child}
-          </SceneComponent>
-        );
-        scenes.push(scene);
-      }
+          selected={(this.state.currentPage === idx)}>
+            {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}
+        </SceneComponent>
+      );
     });
-    return scenes;
   },
 
   _updateSelectedPage(currentPage) {

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ const ScrollableTabView = React.createClass({
   },
 
   _makeSceneKey(child, idx) {
-    return child.props.tabLabel + '_' + idx;
+    return child.key;
   },
 
   renderScrollableContent() {
@@ -190,9 +190,10 @@ const ScrollableTabView = React.createClass({
       return (
         <SceneComponent
           key={key}
+          selected={(this.state.currentPage === idx)}
           style={{width: this.state.containerWidth, }}
-          selected={(this.state.currentPage === idx)}>
-            {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}
+        >
+        {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}
         </SceneComponent>
       );
     });

--- a/index.js
+++ b/index.js
@@ -16,17 +16,10 @@ const {
 } = ReactNative;
 const TimerMixin = require('react-timer-mixin');
 
+const StaticContainer = require('react-static-container');
 const DefaultTabBar = require('./DefaultTabBar');
 const ScrollableTabBar = require('./ScrollableTabBar');
 
-class StaticContainer extends Component{
-  shouldComponentUpdate(nextProps){
-    return !!nextProps.shouldUpdate
-  }
-  render(){
-    return this.props.children
-  }
-}
 
 class SceneComponent extends Component{
   render(){

--- a/index.js
+++ b/index.js
@@ -144,6 +144,39 @@ const ScrollableTabView = React.createClass({
 
   renderScrollableContent() {
     if (Platform.OS === 'ios') {
+      let scenes=[]
+      this._children().forEach((child, idx) => {
+        let key=this._makeSceneKey(child,idx)
+        let selected=false;
+
+        // if key doesnt exist(typically before each tab is first mounted) then put a dummy child instead of real
+        // this ensures # of pages remain the same , leaving scrolling and click tab effect to be handled as intended
+        if(!this._keyExists(this.state.sceneKeys,key)){ 
+          let scene=(
+            <SceneComponent
+            key={key}
+            style={{width: this.state.containerWidth, }}
+            selected={selected}>
+              <View tabLabel={child.props.tabLabel}/>
+            </SceneComponent>
+          )
+          scenes.push(scene)
+        }
+        // if keyexists and the tab is viewed for the first time then SceneComponent is mounted, else its updated and rendered 
+        // Also when a tab is selected,StaticContainer inside the SceneComponent makes sure that only tab being viewed is rendered
+        if(this._keyExists(this.state.sceneKeys,key)){
+          if(idx==this.state.currentPage) selected=true
+          let scene=(
+            <SceneComponent
+            key={key}
+            style={{width: this.state.containerWidth, }}
+            selected={selected}>
+              {child}
+            </SceneComponent>
+          )
+          scenes.push(scene)
+        }
+      })
       return (
         <ScrollView
           horizontal
@@ -179,13 +212,7 @@ const ScrollableTabView = React.createClass({
           alwaysBounceVertical={false}
           keyboardDismissMode="on-drag"
           {...this.props.contentProps}>
-          {this._children().map((child, idx) => {
-            return <View
-              key={child.props.tabLabel + '_' + idx}
-              style={{width: this.state.containerWidth, }}>
-              {child}
-            </View>;
-          })}
+            {scenes}
         </ScrollView>
       );
     } else {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/brentvatne/react-native-scrollable-tab-view#readme",
   "dependencies": {
+    "react-static-container": "^1.0.1",
     "react-timer-mixin": "^0.13.3"
   }
 }


### PR DESCRIPTION
Made code changes to mount only initial tab when loaded and lazily mount other tabs whenever selected. By default it mounts all tabs at once.
Once all tabs are mounted, only renders selected tab instead of all tabs.