### PR TITLE
Add tabKey to prevent child mount/unmount on label change

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ var App = React.createClass({
 - **`locked`** _(Bool)_ - disables horizontal dragging to scroll between tabs, default is false.
 - **`initialPage`** _(Integer)_ - the index of the initially selected tab, defaults to 0 === first tab.
 - **`page`** _(Integer)_ - set selected tab(can be buggy see  [#126](https://github.com/brentvatne/react-native-scrollable-tab-view/issues/126)
-- **`children`** _(ReactComponents)_ - each top-level child component should have a `tabLabel` prop that can be used by the tab bar component to render out the labels. The default tab bar expects it to be a string, but you can use anything you want if you make a custom tab bar.
+- **`children`** _(ReactComponents)_
+  - each top-level child component should have a `tabLabel` prop that can be used by the tab bar component to render out the labels. The default tab bar expects it to be a string, but you can use anything you want if you make a custom tab bar.
+  - top-level child component also accepts `tabKey` that you can use to prevent mount/unmount of the child component when tabLabel changes but you want to keep internal state of the component
 - **`tabBarUnderlineColor`** _(String)_ - color of the default tab bar's underline, defaults to `navy`
 - **`tabBarBackgroundColor`** _(String)_ - color of the default tab bar's background, defaults to `white`
 - **`tabBarActiveTextColor`** _(String)_ - color of the default tab bar's text when active, defaults to `navy`

--- a/index.js
+++ b/index.js
@@ -134,8 +134,10 @@ const ScrollableTabView = React.createClass({
           keyboardDismissMode="on-drag"
           {...this.props.contentProps}>
           {this._children().map((child, idx) => {
+            const key = typeof child.props.tabKey !== 'undefined' ?
+                          child.props.tabKey : child.props.tabLabel + '_' + idx;
             return <View
-              key={child.props.tabLabel + '_' + idx}
+              key={key}
               style={{width: this.state.containerWidth, }}>
               {child}
             </View>;


### PR DESCRIPTION
fix https://github.com/skv-headless/react-native-scrollable-tab-view/issues/148

example code that is broken, it should log only `mounted` once, not when label change
```js
import React from 'react';
import {
    View,
    Text,
} from 'react-native';
import ScrollableTabView from 'react-native-scrollable-tab-view';


class Page extends React.Component {
    componentDidMount() {
        console.log('mounted');
    }
    render() {
        return (<View>
            <Text> Test </Text>
        </View>);
    }
}

export default
class App extends React.Component {
    constructor(props) {
        super(props);
        this.state = {
            i: 0,
        };
    }
    componentDidMount() {
        setInterval(() => {
            this.setState({ i: this.state.i + 1 });
        }, 1000);
    }
    render() {
        const { i } = this.state;
        return (
          <ScrollableTabView>
            <Page tabLabel={`React (${i})`} />
            <Page tabLabel="Flow" />
            <Page tabLabel="Jest" />
          </ScrollableTabView>
        );
    }
}
```