### PR TITLE
Add bounces support

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const ScrollableTabView = React.createClass({
     contentProps: PropTypes.object,
     scrollWithoutAnimation: PropTypes.bool,
     locked: PropTypes.bool,
+    bounces: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -48,6 +49,7 @@ const ScrollableTabView = React.createClass({
       contentProps: {},
       scrollWithoutAnimation: false,
       locked: false,
+      bounces: true
     };
   },
 
@@ -129,6 +131,7 @@ const ScrollableTabView = React.createClass({
           scrollsToTop={false}
           showsHorizontalScrollIndicator={false}
           scrollEnabled={!this.props.locked}
+          bounces={this.props.bounces}
           directionalLockEnabled
           alwaysBounceVertical={false}
           keyboardDismissMode="on-drag"


### PR DESCRIPTION
I added the ios only prop **bounces** which in the documentation says:

When true, the scroll view bounces when it reaches the end of the content if the content is larger then the scroll view along the axis of the scroll direction. When false, it disables all bouncing even if the alwaysBounce* props are true. The default value is true.

I think it would be useful :) and many thanks for your great job !