### PR TITLE
fix for dynamic tabLabel

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,9 @@ const ScrollableTabView = React.createClass({
   },
 
   _makeSceneKey(child, idx) {
-    return child.props.tabLabel + '_' + idx;
+    const { key, taskId } = child.props;
+    const val = key || taskId;
+    return val + '_' + idx;
   },
 
   renderScrollableContent() {


### PR DESCRIPTION
use key instead of tabLabel when available to allow for dynamic text
changes