### PR TITLE
fix first tab doesn't render when upgrading from 0.4.4 to 0.5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,9 @@ const ScrollableTabView = React.createClass({
   },
 
   _keyExists(sceneKeys, key) {
+    if (sceneKeys.length === 0) {
+      sceneKeys.push(key);
+    }
     return sceneKeys.find((sceneKey) => key === sceneKey);
   },
 
@@ -191,7 +194,7 @@ const ScrollableTabView = React.createClass({
         selected={(this.state.currentPage === idx)}
         style={{width: this.state.containerWidth, }}
       >
-        {child}
+        {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}
       </SceneComponent>;
     });
   },

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ const ScrollableTabView = React.createClass({
         selected={(this.state.currentPage === idx)}
         style={{width: this.state.containerWidth, }}
       >
-        {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}
+        {child}
       </SceneComponent>;
     });
   },

--- a/index.js
+++ b/index.js
@@ -116,9 +116,9 @@ const ScrollableTabView = React.createClass({
     return newKeys;
   },
 
-  _keyExists(sceneKeys, key) {
-    if (sceneKeys.length === 0) {
-      sceneKeys.push(key);
+  _keyExists(sceneKeys, key, initialKey) {
+    if (sceneKeys.length === 0 && initialKey !== undefined) {
+      sceneKeys.push(initialKey);
     }
     return sceneKeys.find((sceneKey) => key === sceneKey);
   },
@@ -188,13 +188,17 @@ const ScrollableTabView = React.createClass({
 
   _composeScenes() {
     return this._children().map((child, idx) => {
+      let initialKey;
       let key = this._makeSceneKey(child, idx);
+      if (idx === this.state.currentPage) {
+        initialKey = key;
+      }
       return <SceneComponent
         key={child.key}
         selected={(this.state.currentPage === idx)}
         style={{width: this.state.containerWidth, }}
       >
-        {this._keyExists(this.state.sceneKeys, key) ? child : <View tabLabel={child.props.tabLabel}/>}
+        {this._keyExists(this.state.sceneKeys, key, initialKey) ? child : <View tabLabel={child.props.tabLabel}/>}
       </SceneComponent>;
     });
   },


### PR DESCRIPTION
Fix:
[First tab doesn't render when upgrading from 0.4.4 to 0.5.0](https://github.com/skv-headless/react-native-scrollable-tab-view/issues/317)