### PR TITLE
Make the Tab Button TouchHighlight for Android borderless like in the Twitter App

### DIFF
--- a/Button.android.js
+++ b/Button.android.js
@@ -8,7 +8,7 @@ const {
 const Button = (props) => {
   return <TouchableNativeFeedback
     delayPressIn={0}
-    background={TouchableNativeFeedback.SelectableBackground()} // eslint-disable-line new-cap
+    background={TouchableNativeFeedback.SelectableBackgroundBorderless()} // eslint-disable-line new-cap
     {...props}
   >
     {props.children}


### PR DESCRIPTION
![screenshot 2016-07-19 13 05 401](https://cloud.githubusercontent.com/assets/517703/16947947/4e044ca6-4db2-11e6-9276-2dded4bab37d.jpg)
