### PR TITLE
Prevent page change being reverted due to queued setState

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,12 +66,12 @@ const ScrollableTabView = React.createClass({
   },
 
   componentWillReceiveProps(props) {
-    if (props.page >= 0 && props.page !== this.state.currentPage) {
-      this.goToPage(props.page);
-    }
-
     if (props.children !== this.props.children) {
       this.updateSceneKeys({ page: this.state.currentPage, children: props.children, });
+    }
+
+    if (props.page >= 0 && props.page !== this.state.currentPage) {
+      this.goToPage(props.page);
     }
   },
 


### PR DESCRIPTION
Fixes https://github.com/skv-headless/react-native-scrollable-tab-view/issues/365