### PR TITLE
Add option to give every Tab Button a testID

### DIFF
--- a/DefaultTabBar.js
+++ b/DefaultTabBar.js
@@ -13,6 +13,7 @@ const DefaultTabBar = React.createClass({
     goToPage: React.PropTypes.func,
     activeTab: React.PropTypes.number,
     tabs: React.PropTypes.array,
+    tabsTestIDs: React.PropTypes.array,
     underlineColor: React.PropTypes.string,
     underlineHeight: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
@@ -37,12 +38,14 @@ const DefaultTabBar = React.createClass({
     const { activeTextColor, inactiveTextColor, textStyle, } = this.props;
     const textColor = isTabActive ? activeTextColor : inactiveTextColor;
     const fontWeight = isTabActive ? 'bold' : 'normal';
+    const testID = this.props.tabsTestIDs[page];
 
     return <Button
       style={{flex: 1, }}
       key={name}
       accessible={true}
       accessibilityLabel={name}
+      testID={testID}
       accessibilityTraits='button'
       onPress={() => this.props.goToPage(page)}
     >

--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -18,6 +18,7 @@ const ScrollableTabBar = React.createClass({
     goToPage: React.PropTypes.func,
     activeTab: React.PropTypes.number,
     tabs: React.PropTypes.array,
+    tabsTestIDs: React.PropTypes.array,
     underlineColor: React.PropTypes.string,
     underlineHeight: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
@@ -127,11 +128,13 @@ const ScrollableTabBar = React.createClass({
     const { activeTextColor, inactiveTextColor, textStyle, } = this.props;
     const textColor = isTabActive ? activeTextColor : inactiveTextColor;
     const fontWeight = isTabActive ? 'bold' : 'normal';
+    const testID = this.props.tabsTestIDs[page];
 
     return <Button
       key={`${name}_${page}`}
       accessible={true}
       accessibilityLabel={name}
+      testID={testID}
       accessibilityTraits='button'
       onPress={() => this.props.goToPage(page)}
       onLayout={this.measureTab.bind(this, page)}

--- a/index.js
+++ b/index.js
@@ -257,6 +257,7 @@ const ScrollableTabView = React.createClass({
     let tabBarProps = {
       goToPage: this.goToPage,
       tabs: this._children().map((child) => child.props.tabLabel),
+      tabsTestIDs: this._children().map((child) => child.props.tabTestID),
       activeTab: this.state.currentPage,
       scrollValue: this.state.scrollValue,
       containerWidth: this.state.containerWidth,


### PR DESCRIPTION
We needed a way for our acceptance tests to reference each Tab Button without relying on the Tab name which in our case is a translated string which might be changed in the future.