### PR TITLE
fix crash on android <= 4.4 (#397)

### DIFF
--- a/Button.android.js
+++ b/Button.android.js
@@ -2,13 +2,15 @@ const React = require('react');
 const ReactNative = require('react-native');
 const {
   TouchableNativeFeedback,
-  View,
+  View, Platform
 } = ReactNative;
+
+const API21 = (Platform.OS === "android" && Platform["Version"] >= 21);
 
 const Button = (props) => {
   return <TouchableNativeFeedback
     delayPressIn={0}
-    background={TouchableNativeFeedback.SelectableBackgroundBorderless()} // eslint-disable-line new-cap
+    background={API21 ? TouchableNativeFeedback.SelectableBackgroundBorderless() : TouchableNativeFeedback.SelectableBackground()} // eslint-disable-line new-cap
     {...props}
   >
     {props.children}


### PR DESCRIPTION
closes #397 that was caused by the use of TouchableNativeFeedback.SelectableBackgroundBorderless() which is only available for Android API>=21

It just fallbacks to TouchableNativeFeedback.SelectableBackground() is the API is <21.