### PR TITLE
Round width when using onLayout

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ const ScrollableTabView = React.createClass({
   _handleLayout(e) {
     const { width, } = e.nativeEvent.layout;
 
-    if (width !== this.state.containerWidth) {
+    if (Math.round(width, 2) !== Math.round(this.state.containerWidth, 2)) {
       this.setState({ containerWidth: width, });
       this.requestAnimationFrame(() => {
         this.goToPage(this.state.currentPage);

--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ const ScrollableTabView = React.createClass({
   _handleLayout(e) {
     const { width, } = e.nativeEvent.layout;
 
-    if (Math.round(width, 2) !== Math.round(this.state.containerWidth, 2)) {
+    if (Math.round(width) !== Math.round(this.state.containerWidth)) {
       this.setState({ containerWidth: width, });
       this.requestAnimationFrame(() => {
         this.goToPage(this.state.currentPage);


### PR DESCRIPTION
Sometimes the width returned by e.nativeEvent.layout.width is off by a few decimals, since it looks like this check is made to detect orientation changes, we can use Math.round in order to avoid this issue.

In my nexus 6P I can consistently reproduce it by loading a fullscreen tab and the width  it's off by 0.0001  and this generates an extra call to goToPage which causes the content of my tab to re-render.

To reproduce the problem, I've added this logs: 

![screen shot 2016-09-02 at 1 57 35 pm](https://cloud.githubusercontent.com/assets/1247834/18213822/0f64ca1e-7118-11e6-89bf-102c38b7c357.png)

and this was the output:

![screen shot 2016-09-02 at 1 57 20 pm](https://cloud.githubusercontent.com/assets/1247834/18213873/4ab1525e-7118-11e6-95ac-795c6878e058.png)

As you can see the first time it ran the widths are different:

 e.nativeEvent.layout.width: 411.4285583496094,
 this.state.containerWidth:  411.42857142857144

Adding Math.round(width, 2) solved this issue.



 