### PR TITLE
allows to force scroll view for #187

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ To start you can just copy [DefaultTabBar](https://github.com/skv-headless/react
 - **`contentProps`** _(Object)_ - props that are applied to root `ScrollView`/`ViewPagerAndroid`. Note that overriding defaults set by the library may break functionality; see the source for details.
 - **`scrollWithoutAnimation`** _(Bool)_ - on tab press change tab without animation.
 - **`prerenderingSiblingsNumber`** _(Integer)_ - pre-render nearby # sibling, `Infinity` === render all the siblings, default to 0 === render current page.
+- **`forceScrollView`** _(Boolean)_ - Forces the use of `ScrollView` instead of `ViewPagerAndroid`. See [this issue](https://github.com/skv-headless/react-native-scrollable-tab-view/issues/187) .
 
 ## Contribution
 **Issues** are welcome. Please add a screenshot of bug and code snippet. Quickest way to solve issue is to reproduce it on one of the examples.

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ const ScrollableTabView = React.createClass({
     scrollWithoutAnimation: PropTypes.bool,
     locked: PropTypes.bool,
     prerenderingSiblingsNumber: PropTypes.number,
+    forceScrollView: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -53,6 +54,7 @@ const ScrollableTabView = React.createClass({
       scrollWithoutAnimation: false,
       locked: false,
       prerenderingSiblingsNumber: 0,
+      forceScrollView: false,
     };
   },
 
@@ -140,7 +142,7 @@ const ScrollableTabView = React.createClass({
   },
 
   renderScrollableContent() {
-    if (Platform.OS === 'ios') {
+    if (this.props.forceScrollView || Platform.OS === 'ios') {
       const scenes = this._composeScenes();
       return <ScrollView
         horizontal


### PR DESCRIPTION
To accommodate your reluctancy to remove entirely the `ViewPagerAndroid`, and based on @crozzfire's [PR](https://github.com/skv-headless/react-native-scrollable-tab-view/pull/381), I've added a property to force `ScrollView`