### PR TITLE
Fix the initial underline positioning when initialPage is anything other than 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ const ScrollableTabView = React.createClass({
 
   getInitialState() {
     return {
+      acceptScrollEvents: false,
       currentPage: this.props.initialPage,
       scrollValue: new Animated.Value(this.props.initialPage),
       containerWidth: Dimensions.get('window').width,
@@ -71,6 +72,12 @@ const ScrollableTabView = React.createClass({
     if (props.page >= 0 && props.page !== this.state.currentPage) {
       this.goToPage(props.page);
     }
+  },
+
+  componentDidMount() {
+    InteractionManager.runAfterInteractions(() => {
+      this.setState({ acceptScrollEvents: true });
+    });
   },
 
   goToPage(pageNumber) {
@@ -136,8 +143,10 @@ const ScrollableTabView = React.createClass({
       contentOffset={{ x: this.props.initialPage * this.state.containerWidth, }}
       ref={(scrollView) => { this.scrollView = scrollView; }}
       onScroll={(e) => {
-        const offsetX = e.nativeEvent.contentOffset.x;
-        this._updateScrollValue(offsetX / this.state.containerWidth);
+        if (this.state.acceptScrollEvents) {
+          const offsetX = e.nativeEvent.contentOffset.x;
+          this._updateScrollValue(offsetX / this.state.containerWidth);
+        }
       }}
       onMomentumScrollBegin={this._onMomentumScrollBeginAndEnd}
       onMomentumScrollEnd={this._onMomentumScrollBeginAndEnd}


### PR DESCRIPTION
Currently in `v0.6.0`, the underline positioning is initially incorrect when you set `initialPage` to anything greater than 0. This is because the `<ScrollView>`'s `onScroll` prop is called immediately, which always resets the `scrollValue` to 0. I'm ignoring that initial event by using `runAfterInteractions()` in `componentDidMount()`. Perhaps there is a better way, but this is working correctly.