### PR TITLE
fix(ScrollableTabBar): ScrollView automaticallyAdjustContentInsets={f…

### DIFF
--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -166,6 +166,7 @@ const ScrollableTabBar = React.createClass({
       onLayout={this.onContainerLayout}
     >
       <ScrollView
+        automaticallyAdjustContentInsets={false}
         ref={(scrollView) => { this._scrollView = scrollView; }}
         horizontal={true}
         showsHorizontalScrollIndicator={false}


### PR DESCRIPTION
…alse}

This fixes vertical scrolling of the ScrollableTabBar on IOS. When not rendered right at the top of the page the whole tabs container could scroll vertically behind the container view due to the component trying to automatically adjust itself. This fix gives the styling back to the view

