### PR TITLE
fix progress-computation in FacebookTabBar

### DIFF
--- a/examples/FacebookTabsExample/FacebookTabBar.js
+++ b/examples/FacebookTabsExample/FacebookTabBar.js
@@ -22,7 +22,7 @@ const FacebookTabBar = React.createClass({
 
   setAnimationValue({ value, }) {
     this.tabIcons.forEach((icon, i) => {
-      const progress = (value - i >= 0 && value - i <= 1) ? value - i : 1;
+      const progress = Math.min(1, Math.abs(value - i))
       icon.setNativeProps({
         style: {
           color: this.iconColor(progress),


### PR DESCRIPTION
The progress should be computed by using the absolute distance between each tab and the current animation-position. This enables smooth transitions from both sides rather than only during back-transitions.