### PR TITLE
Support tabBarStyle prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ To start you can just copy [DefaultTabBar](https://github.com/skv-headless/react
 - **`tabBarActiveTextColor`** _(String)_ - color of the default tab bar's text when active, defaults to `navy`
 - **`tabBarInactiveTextColor`** _(String)_ - color of the default tab bar's text when inactive, defaults to `black`
 - **`tabBarTextStyle`** _(Object)_ - Additional styles to the tab bar's text. Example: `{fontFamily: 'Roboto', fontSize: 15}`
+- **`tabBarStyle`** _(Object)_ - Additional styles to the tab bar. Example: `{borderBottomWidth: 0}`
 - **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))_
 - **`contentProps`** _(Object)_ - props that are applied to root `ScrollView`/`ViewPagerAndroid`. Note that overriding defaults set by the library may break functionality; see the source for details.
 - **`scrollWithoutAnimation`** _(Bool)_ - on tab press change tab without animation.

--- a/index.js
+++ b/index.js
@@ -259,6 +259,9 @@ const ScrollableTabView = React.createClass({
         [this.props.tabBarPosition === 'overlayTop' ? 'top' : 'bottom']: 0,
       };
     }
+    if (this.props.tabBarStyle) {
+      tabBarProps.style = { ...tabBarProps.style, ...this.props.tabBarStyle };
+    }
 
     return <View style={[styles.container, this.props.style, ]} onLayout={this._handleLayout}>
       {this.props.tabBarPosition === 'top' && this.renderTabBar(tabBarProps)}


### PR DESCRIPTION
FYI, I made a [previous PR](https://github.com/skv-headless/react-native-scrollable-tab-view/pull/413) to handle my particular styling case, but this is a more general solution for tab bar styling.

If you want to use the `DefaultTabBar`, but want to tweak the style of the tab bar itself, you can use the new `tabBarStyle` prop.

I'm using this to set the `{ borderBottomWidth: 0}`, since there is no other way to clear the 1px #ccc border that's hardcoded in `DefaultTabBar.js`.