### PR TITLE
Add passthrough for RefreshControl

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ const ScrollableTabView = React.createClass({
     scrollWithoutAnimation: PropTypes.bool,
     locked: PropTypes.bool,
     prerenderingSiblingsNumber: PropTypes.number,
+    refreshControl: PropTypes.object
   },
 
   getDefaultProps() {
@@ -52,6 +53,7 @@ const ScrollableTabView = React.createClass({
       scrollWithoutAnimation: false,
       locked: false,
       prerenderingSiblingsNumber: 0,
+      refreshControl: null
     };
   },
 
@@ -145,6 +147,7 @@ const ScrollableTabView = React.createClass({
     return <ScrollView
       horizontal
       pagingEnabled
+      refreshControl={this.props.refreshControl}
       automaticallyAdjustContentInsets={false}
       contentOffset={{ x: this.props.initialPage * this.state.containerWidth, }}
       ref={(scrollView) => { this.scrollView = scrollView; }}


### PR DESCRIPTION
It's nice to be able to use React Native's RefreshControl to show a loading indicator and pull to refresh inside of a tab group.

This PR adds a passthrough so you can use it as you would with a normal ScrollView