### PR TITLE
Fix invalid object rest syntax

### DIFF
--- a/SceneComponent.js
+++ b/SceneComponent.js
@@ -6,7 +6,7 @@ const {View, StyleSheet, } = ReactNative;
 const StaticContainer = require('./StaticContainer');
 
 const SceneComponent = (Props) => {
-  const {shouldUpdated, ...props, } = Props;
+  const {shouldUpdated, ...props} = Props;
   return <View {...props}>
       <StaticContainer shouldUpdate={shouldUpdated}>
         {props.children}


### PR DESCRIPTION
Trailing commas are not allowed after the rest element, this is not enforced by babel 6 but is by babel 7.