### PR TITLE
Removed trailing comma, which is a breaking change for RN 0.56

### DIFF
--- a/SceneComponent.js
+++ b/SceneComponent.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const ReactNative = require('react-native');
-const {Component, } = React;
-const {View, StyleSheet, } = ReactNative;
+const {Component } = React;
+const {View, StyleSheet } = ReactNative;
 
 const StaticContainer = require('./StaticContainer');
 


### PR DESCRIPTION
When the trailing comma exists, we will receive following error:

``
error: bundling failed: SyntaxError: /Users/Doko/Projects/ReactNative/gplx/node_modules/react-native-scrollable-tab-view/SceneComponent.js: A trailing comma is not permitted after the rest element (9:32)
``

This PR fixed that error for anyone who caught it. Even if they don't, those commas are useless anyway.