### PR TITLE
Fix tab bar underline style

### DIFF
--- a/DefaultTabBar.js
+++ b/DefaultTabBar.js
@@ -86,7 +86,7 @@ const DefaultTabBar = createReactClass({
                 { translateX },
               ]
             },
-            this.props.tabBarUnderlineStyle,
+            this.props.underlineStyle,
           ]}
         />
       </View>


### PR DESCRIPTION
The current DefaultTabBar is merging the wrong props for underline style
This PR fixes that.