### PR TITLE
updated dependency @react-native-community/viewpager to v4.1.6 and move to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   },
   "homepage": "https://github.com/brentvatne/react-native-scrollable-tab-view#readme",
   "dependencies": {
-    "@react-native-community/viewpager": "3.3.0",
     "create-react-class": "^15.6.2",
     "deprecated-react-native-prop-types": "^2.3.0",
     "prop-types": "^15.6.0",
     "react-timer-mixin": "^0.13.3"
+  },
+  "peerDependencies":{
+     "@react-native-community/viewpager": ">=4.1.6"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Changed it from dependencies to peerDependencies because if two diferent versions of @react-native-community/viewpager are installed in a project a "Tried to register two views with the same name RNCViewPager" error is raised.